### PR TITLE
feat: AI設定ボタンを別場所に新規作成

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -7,11 +7,15 @@ import ProjectCard from '@/components/project/ProjectCard'
 import CreateProjectModal from '@/components/project/CreateProjectModal'
 import Button from '@/components/ui/Button'
 import Link from 'next/link'
+import AISettings, { AISettingsData } from '@/components/settings/AISettings'
+import { useAppStore } from '@/lib/store'
 
 export default function ProjectsPage() {
   const [projects, setProjects] = useState<Project[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [showCreateModal, setShowCreateModal] = useState(false)
+  const [showAISettings, setShowAISettings] = useState(false)
+  const { setCurrentProvider, setApiKey } = useAppStore()
 
   const loadProjects = async () => {
     setIsLoading(true)
@@ -53,6 +57,11 @@ export default function ProjectsPage() {
     }
   }
 
+  const handleAISettingsSave = (settings: AISettingsData) => {
+    setCurrentProvider(settings.provider)
+    setApiKey(settings.provider, settings.apiKey)
+  }
+
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       <div className="max-w-7xl mx-auto px-4 py-8">
@@ -67,6 +76,12 @@ export default function ProjectsPage() {
                   ホームに戻る
                 </Button>
               </Link>
+              <Button
+                variant="secondary"
+                onClick={() => setShowAISettings(true)}
+              >
+                AI設定
+              </Button>
               <Button
                 onClick={() => setShowCreateModal(true)}
               >
@@ -128,6 +143,12 @@ export default function ProjectsPage() {
           isOpen={showCreateModal}
           onClose={() => setShowCreateModal(false)}
           onCreated={loadProjects}
+        />
+
+        <AISettings
+          isOpen={showAISettings}
+          onClose={() => setShowAISettings(false)}
+          onSave={handleAISettingsSave}
         />
       </div>
     </div>

--- a/src/components/project/CreateProjectModal.tsx
+++ b/src/components/project/CreateProjectModal.tsx
@@ -11,6 +11,7 @@ import { worldService } from '@/lib/services/world-service'
 import { aiManager } from '@/lib/ai/manager'
 import { useAppStore } from '@/lib/store'
 import { NOVEL_TYPE_CONFIGS } from '@/lib/config/novel-types'
+import AISettings, { AISettingsData } from '@/components/settings/AISettings'
 
 interface CreateProjectModalProps {
   isOpen: boolean
@@ -34,8 +35,9 @@ export default function CreateProjectModal({ isOpen, onClose, onCreated }: Creat
   const [isGenerating, setIsGenerating] = useState(false)
   const [generationProgress, setGenerationProgress] = useState<GenerationProgress | null>(null)
   const [generationComplete, setGenerationComplete] = useState(false)
+  const [showAISettings, setShowAISettings] = useState(false)
   
-  const { currentProvider } = useAppStore()
+  const { currentProvider, setCurrentProvider, setApiKey } = useAppStore()
 
   const handleCreate = async () => {
     if (!name.trim()) {
@@ -140,14 +142,21 @@ export default function CreateProjectModal({ isOpen, onClose, onCreated }: Creat
     onClose()
   }
 
+  const handleAISettingsSave = (settings: AISettingsData) => {
+    setCurrentProvider(settings.provider)
+    setApiKey(settings.provider, settings.apiKey)
+    setError('') // APIキー設定後はエラーをクリア
+  }
+
   return (
-    <Modal
-      isOpen={isOpen}
-      onClose={handleClose}
-      title="新規プロジェクト作成"
-    >
-      <div className="space-y-4">
-        {!isGenerating ? (
+    <>
+      <Modal
+        isOpen={isOpen}
+        onClose={handleClose}
+        title="新規プロジェクト作成"
+      >
+        <div className="space-y-4">
+          {!isGenerating ? (
           <>
             <Input
               label="プロジェクト名"
@@ -244,7 +253,18 @@ export default function CreateProjectModal({ isOpen, onClose, onCreated }: Creat
             </div>
 
             {error && (
-              <p className="text-sm text-red-600">{error}</p>
+              <div className="space-y-2">
+                <p className="text-sm text-red-600">{error}</p>
+                {error.includes('AIプロバイダーが設定されていません') && (
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => setShowAISettings(true)}
+                  >
+                    AI設定を開く
+                  </Button>
+                )}
+              </div>
             )}
 
             <div className="flex justify-end gap-3 pt-4">
@@ -332,5 +352,12 @@ export default function CreateProjectModal({ isOpen, onClose, onCreated }: Creat
         )}
       </div>
     </Modal>
+
+    <AISettings
+      isOpen={showAISettings}
+      onClose={() => setShowAISettings(false)}
+      onSave={handleAISettingsSave}
+    />
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- プロジェクト一覧画面のAI設定ボタンを追加
- 新規プロジェクト作成時のAPIキー未設定エラーでAI設定ボタンを表示

## Test plan
- [ ] プロジェクト一覧画面でAI設定ボタンが表示されることを確認
- [ ] AI設定ボタンクリックでモーダルが開くことを確認
- [ ] 新規プロジェクト作成でAI生成を使用し、APIキー未設定の場合にエラーと設定ボタンが表示されることを確認

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)