### PR TITLE
fix: improve text color contrast in AI settings page

### DIFF
--- a/src/components/settings/AIModelSelector.tsx
+++ b/src/components/settings/AIModelSelector.tsx
@@ -91,7 +91,7 @@ export default function AIModelSelector({
   return (
     <div className="space-y-4">
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
           AIモデル
         </label>
         {!showCustomInput ? (
@@ -137,30 +137,30 @@ export default function AIModelSelector({
       </div>
 
       {selectedModel && !showCustomInput && (
-        <div className="bg-gray-50 rounded-lg p-4 space-y-2">
-          <h4 className="font-medium text-sm text-gray-900">
+        <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 space-y-2">
+          <h4 className="font-medium text-sm text-gray-900 dark:text-gray-100">
             {selectedModel.name}
           </h4>
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-gray-600 dark:text-gray-400">
             {selectedModel.description}
           </p>
           <div className="flex flex-wrap gap-2 mt-2">
             {selectedModel.capabilities.map((cap) => (
               <span
                 key={cap}
-                className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-700"
+                className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300"
               >
                 {cap}
               </span>
             ))}
           </div>
           {selectedModel.contextWindow > 0 && (
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-gray-500 dark:text-gray-400">
               コンテキストウィンドウ: {selectedModel.contextWindow.toLocaleString()} トークン
             </p>
           )}
           {'pricing' in selectedModel && selectedModel.pricing && (
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-gray-500 dark:text-gray-400">
               価格: ${selectedModel.pricing.input}/1M 入力 | ${selectedModel.pricing.output}/1M 出力
             </p>
           )}

--- a/src/components/settings/AISettings.tsx
+++ b/src/components/settings/AISettings.tsx
@@ -143,7 +143,7 @@ export default function AISettings({ isOpen, onClose, onSave }: AISettingsProps)
     >
       <div className="space-y-6">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             AIプロバイダー
           </label>
           <Select
@@ -176,9 +176,9 @@ export default function AISettings({ isOpen, onClose, onSave }: AISettingsProps)
 
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Temperature
-              <span className="ml-2 text-xs text-gray-500">
+              <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">
                 ({temperature})
               </span>
             </label>
@@ -191,7 +191,7 @@ export default function AISettings({ isOpen, onClose, onSave }: AISettingsProps)
               onChange={(e) => setTemperature(parseFloat(e.target.value))}
               className="w-full"
             />
-            <div className="flex justify-between text-xs text-gray-500 mt-1">
+            <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-1">
               <span>確定的</span>
               <span>創造的</span>
             </div>
@@ -207,11 +207,11 @@ export default function AISettings({ isOpen, onClose, onSave }: AISettingsProps)
           />
         </div>
 
-        <div className="bg-blue-50 rounded-lg p-4">
-          <h4 className="text-sm font-medium text-blue-900 mb-2">
+        <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-4">
+          <h4 className="text-sm font-medium text-blue-900 dark:text-blue-300 mb-2">
             APIキーの取得方法
           </h4>
-          <ul className="text-sm text-blue-700 space-y-1">
+          <ul className="text-sm text-blue-700 dark:text-blue-400 space-y-1">
             {provider === 'openai' ? (
               <>
                 <li>1. <a href="https://platform.openai.com/api-keys" target="_blank" rel="noopener noreferrer" className="underline">OpenAI Platform</a> にアクセス</li>

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -11,13 +11,13 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
     return (
       <div className="w-full">
         {label && (
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             {label}
           </label>
         )}
         <input
           className={cn(
-            'block w-full rounded-md border border-gray-300 px-3 py-2 text-base shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:bg-gray-50 disabled:text-gray-500',
+            'block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3 py-2 text-base shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:bg-gray-50 dark:disabled:bg-gray-700 disabled:text-gray-500 dark:disabled:text-gray-400',
             error && 'border-red-500 focus:border-red-500 focus:ring-red-500',
             className
           )}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -18,7 +18,7 @@ const Select = forwardRef<HTMLSelectElement, SelectProps>(
     return (
       <select
         className={cn(
-          'block w-full rounded-md border border-gray-300 bg-white shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:bg-gray-50 disabled:text-gray-500',
+          'block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:bg-gray-50 dark:disabled:bg-gray-700 disabled:text-gray-500 dark:disabled:text-gray-400',
           {
             'h-8 px-2 text-sm': size === 'sm',
             'h-10 px-3 text-base': size === 'md',


### PR DESCRIPTION
## Summary

This PR fixes the text color visibility issues in the AI settings page where text colors were too similar to background colors.

## Changes

- Added dark mode support to Input and Select components
- Fixed text color visibility for API key input, AI provider, model selector, and max tokens
- Added proper text colors (text-gray-900 dark:text-gray-100) to form inputs
- Updated labels to have better contrast in both light and dark modes
- Fixed background and text colors in AIModelSelector info box
- Improved visibility of all text elements in AI settings

Fixes #20

Generated with [Claude Code](https://claude.ai/code)