### PR TITLE
fix: AI使用回数表示を実装

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react'
 import Button from '@/components/ui/Button'
 import Header from '@/components/layout/Header'
 import { PLANS } from '@/lib/stripe'
+import AIUsageDisplay from '@/components/ai/AIUsageDisplay'
 
 export default function AccountPage() {
   const { data: session, status } = useSession()
@@ -165,6 +166,18 @@ export default function AccountPage() {
                 )}
               </div>
             </div>
+          </div>
+        </div>
+
+        <div className="mt-8 bg-white dark:bg-gray-800 shadow rounded-lg">
+          <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+            <h2 className="text-lg font-medium text-gray-900 dark:text-white">
+              AI使用状況
+            </h2>
+          </div>
+
+          <div className="px-6 py-4">
+            <AIUsageDisplay className="max-w-md" />
           </div>
         </div>
 

--- a/src/components/ai/CompactAIUsageDisplay.tsx
+++ b/src/components/ai/CompactAIUsageDisplay.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { AIUsageStats, getAIUsageStats } from '@/lib/utils/ai-usage-client'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
+import Link from 'next/link'
+
+export default function CompactAIUsageDisplay() {
+  const [stats, setStats] = useState<AIUsageStats | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const { isAuthenticated } = useCurrentUser()
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      loadStats()
+    }
+  }, [isAuthenticated])
+
+  const loadStats = async () => {
+    setIsLoading(true)
+    try {
+      const loadedStats = await getAIUsageStats()
+      if (loadedStats) {
+        setStats(loadedStats)
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  if (isLoading || !stats) {
+    return null
+  }
+
+  const usageColor = stats.isUnlimited 
+    ? 'text-green-600' 
+    : stats.remaining === 0 
+      ? 'text-red-600' 
+      : 'text-gray-600 dark:text-gray-400'
+
+  return (
+    <Link href="/account" className="flex items-center space-x-2 px-3 py-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+      <svg className="h-4 w-4 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+      </svg>
+      <span className={`text-sm font-medium ${usageColor}`}>
+        {stats.isUnlimited ? (
+          '無制限'
+        ) : (
+          `${stats.remaining}/${stats.limit}`
+        )}
+      </span>
+    </Link>
+  )
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import Button from '@/components/ui/Button'
+import CompactAIUsageDisplay from '@/components/ai/CompactAIUsageDisplay'
 
 export default function Header() {
   const { data: session } = useSession()
@@ -40,6 +41,9 @@ export default function Header() {
                     アカウント
                   </Button>
                 </Link>
+                <div className="ml-2 border-l border-gray-300 dark:border-gray-600 pl-2">
+                  <CompactAIUsageDisplay />
+                </div>
                 <div className="ml-2 flex items-center space-x-2">
                   {session.user?.image && (
                     <img
@@ -128,6 +132,9 @@ export default function Header() {
                   </button>
                 </Link>
                 <div className="px-3 py-2 border-t border-gray-200 dark:border-gray-700">
+                  <div className="mb-3">
+                    <CompactAIUsageDisplay />
+                  </div>
                   <div className="flex items-center mb-3">
                     {session.user?.image && (
                       <img


### PR DESCRIPTION
## 概要

AI生成回数の表示が機能していない問題を修正しました。

## 変更内容
- アカウントページにAI使用状況セクションを追加
- ヘッダーにコンパクトなAI使用回数表示を追加
- モバイルナビゲーションにも同様の表示を追加

Closes #39

Generated with [Claude Code](https://claude.ai/code)