### PR TITLE
fix: 章立てが存在しない場合でも章立てボタンを表示

### DIFF
--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -713,13 +713,11 @@ ${pendingChapter.content}
                    aiUsageStats && !aiUsageStats.isUnlimited && aiUsageStats.remaining === 0 ? '使用制限に達しました' :
                    `第${chapters.length > 0 ? Math.max(...chapters.map(ch => ch.number)) + 1 : 1}章を執筆${aiUsageStats && !aiUsageStats.isUnlimited ? ` (残り${aiUsageStats.remaining}回)` : ''}`}
                 </Button>
-                {chapterStructure && (
-                  <Link href={`/projects/${projectId}/setup-chapters`}>
-                    <Button variant="secondary">
-                      📚 章立てを編集
-                    </Button>
-                  </Link>
-                )}
+                <Link href={`/projects/${projectId}/setup-chapters`}>
+                  <Button variant="secondary">
+                    📚 {chapterStructure ? '章立てを編集' : '章立てを作成'}
+                  </Button>
+                </Link>
               </div>
 
               {executionLog.length > 0 && (


### PR DESCRIPTION
新規プロジェクト作成時にAI章立てが失敗またはスキップされた場合、章立てを作成する方法がない問題を修正しました。

- 章立てボタンを常に表示するように変更
- 章立てが存在しない場合は「章立てを作成」と表示
- 章立てが存在する場合は「章立てを編集」と表示

Fixes #49

Generated with [Claude Code](https://claude.ai/code)