### PR TITLE
fix: improve mobile responsive design for project pages

### DIFF
--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -657,33 +657,52 @@ ${pendingChapter.content}
       <div className="max-w-7xl mx-auto px-4 py-8">
         {/* ヘッダー */}
         <div className="mb-8">
-          <div className="flex items-center justify-between mb-4">
+          <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 mb-4">
             <div>
-              <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+              <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-white break-words">
                 {project.name}
               </h1>
-              <p className="text-gray-600 dark:text-gray-400 mt-1">
+              <p className="text-gray-600 dark:text-gray-400 mt-1 text-sm sm:text-base">
                 {project.description || '説明なし'}
               </p>
             </div>
-            <div className="flex gap-3">
+            <div className="flex flex-wrap gap-2 sm:gap-3">
               <Link href="/projects">
-                <Button variant="secondary">
+                <Button variant="secondary" size="sm" className="sm:hidden">
+                  一覧
+                </Button>
+                <Button variant="secondary" className="hidden sm:inline-flex">
                   プロジェクト一覧
                 </Button>
               </Link>
               <Link href={`/projects/${projectId}/dashboard`}>
-                <Button variant="primary">
+                <Button variant="primary" size="sm" className="sm:hidden">
+                  🎯 ダッシュボード
+                </Button>
+                <Button variant="primary" className="hidden sm:inline-flex">
                   🎯 統合ダッシュボード
                 </Button>
               </Link>
-              <Button variant="secondary" onClick={() => setShowAISettings(true)}>
+              <Button variant="secondary" size="sm" onClick={() => setShowAISettings(true)} className="sm:hidden">
                 AI設定
+              </Button>
+              <Button variant="secondary" onClick={() => setShowAISettings(true)} className="hidden sm:inline-flex">
+                AI設定
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowAdvancedAISettings(true)}
+                title="機能別AIモデル設定"
+                className="sm:hidden"
+              >
+                ⚙️
               </Button>
               <Button
                 variant="secondary"
                 onClick={() => setShowAdvancedAISettings(true)}
                 title="機能別AIモデル設定"
+                className="hidden sm:inline-flex"
               >
                 ⚙️ 高度なAI設定
               </Button>

--- a/src/app/projects/[id]/rules/page.tsx
+++ b/src/app/projects/[id]/rules/page.tsx
@@ -133,37 +133,39 @@ export default function WritingRulesPage() {
 
         {/* タブナビゲーション */}
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow mb-6">
-          <div className="flex border-b border-gray-200 dark:border-gray-700">
-            <button
-              onClick={() => setActiveTab('basic')}
-              className={`px-6 py-3 font-medium transition-colors ${
-                activeTab === 'basic'
-                  ? 'text-blue-600 border-b-2 border-blue-600'
-                  : 'text-gray-600 hover:text-gray-900'
-              }`}
-            >
-              基本設定
-            </button>
-            <button
-              onClick={() => setActiveTab('style')}
-              className={`px-6 py-3 font-medium transition-colors ${
-                activeTab === 'style'
-                  ? 'text-blue-600 border-b-2 border-blue-600'
-                  : 'text-gray-600 hover:text-gray-900'
-              }`}
-            >
-              文体・スタイル
-            </button>
-            <button
-              onClick={() => setActiveTab('guidelines')}
-              className={`px-6 py-3 font-medium transition-colors ${
-                activeTab === 'guidelines'
-                  ? 'text-blue-600 border-b-2 border-blue-600'
-                  : 'text-gray-600 hover:text-gray-900'
-              }`}
-            >
-              執筆ガイドライン
-            </button>
+          <div className="overflow-x-auto">
+            <div className="flex border-b border-gray-200 dark:border-gray-700 min-w-max">
+              <button
+                onClick={() => setActiveTab('basic')}
+                className={`px-4 sm:px-6 py-3 font-medium transition-colors whitespace-nowrap ${
+                  activeTab === 'basic'
+                    ? 'text-blue-600 border-b-2 border-blue-600'
+                    : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+                }`}
+              >
+                基本設定
+              </button>
+              <button
+                onClick={() => setActiveTab('style')}
+                className={`px-4 sm:px-6 py-3 font-medium transition-colors whitespace-nowrap ${
+                  activeTab === 'style'
+                    ? 'text-blue-600 border-b-2 border-blue-600'
+                    : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+                }`}
+              >
+                文体・スタイル
+              </button>
+              <button
+                onClick={() => setActiveTab('guidelines')}
+                className={`px-4 sm:px-6 py-3 font-medium transition-colors whitespace-nowrap ${
+                  activeTab === 'guidelines'
+                    ? 'text-blue-600 border-b-2 border-blue-600'
+                    : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+                }`}
+              >
+                執筆ガイドライン
+              </button>
+            </div>
           </div>
 
           <div className="p-6">
@@ -269,7 +271,7 @@ export default function WritingRulesPage() {
                   <textarea
                     value={rules.style}
                     onChange={(e) => setRules({ ...rules, style: e.target.value })}
-                    className="block w-full rounded-md border border-gray-300 px-3 py-2 text-base shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    className="block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-400 px-3 py-2 text-base shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
                     rows={10}
                     placeholder="執筆時の文体に関するルールを記述..."
                   />

--- a/src/app/projects/[id]/world/page.tsx
+++ b/src/app/projects/[id]/world/page.tsx
@@ -296,67 +296,71 @@ export default function WorldSettingsPage() {
 
         {/* タブナビゲーション */}
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow mb-6">
-          <div className="flex border-b border-gray-200 dark:border-gray-700">
-            <button
-              onClick={() => setActiveTab('basic')}
-              className={`px-6 py-3 font-medium transition-colors ${
-                activeTab === 'basic'
-                  ? 'text-blue-600 border-b-2 border-blue-600'
-                  : 'text-gray-600 hover:text-gray-900'
-              }`}
-            >
-              基本情報
-            </button>
-            <button
-              onClick={() => setActiveTab('geography')}
-              className={`px-6 py-3 font-medium transition-colors ${
-                activeTab === 'geography'
-                  ? 'text-blue-600 border-b-2 border-blue-600'
-                  : 'text-gray-600 hover:text-gray-900'
-              }`}
-            >
-              地理
-            </button>
-            <button
-              onClick={() => setActiveTab('cultures')}
-              className={`px-6 py-3 font-medium transition-colors ${
-                activeTab === 'cultures'
-                  ? 'text-blue-600 border-b-2 border-blue-600'
-                  : 'text-gray-600 hover:text-gray-900'
-              }`}
-            >
-              文化
-            </button>
-            <button
-              onClick={() => setActiveTab('magic')}
-              className={`px-6 py-3 font-medium transition-colors ${
-                activeTab === 'magic'
-                  ? 'text-blue-600 border-b-2 border-blue-600'
-                  : 'text-gray-600 hover:text-gray-900'
-              }`}
-            >
-              魔法・特殊能力
-            </button>
-            <button
-              onClick={() => setActiveTab('map')}
-              className={`px-6 py-3 font-medium transition-colors ${
-                activeTab === 'map'
-                  ? 'text-blue-600 border-b-2 border-blue-600'
-                  : 'text-gray-600 hover:text-gray-900'
-              }`}
-            >
-              地図
-            </button>
-            <button
-              onClick={() => setActiveTab('travel')}
-              className={`px-6 py-3 font-medium transition-colors ${
-                activeTab === 'travel'
-                  ? 'text-blue-600 border-b-2 border-blue-600'
-                  : 'text-gray-600 hover:text-gray-900'
-              }`}
-            >
-              旅行シミュレーター
-            </button>
+          <div className="overflow-x-auto">
+            <div className="flex border-b border-gray-200 dark:border-gray-700 min-w-max">
+              <button
+                onClick={() => setActiveTab('basic')}
+                className={`px-4 sm:px-6 py-3 font-medium transition-colors whitespace-nowrap ${
+                  activeTab === 'basic'
+                    ? 'text-blue-600 border-b-2 border-blue-600'
+                    : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+                }`}
+              >
+                基本情報
+              </button>
+              <button
+                onClick={() => setActiveTab('geography')}
+                className={`px-4 sm:px-6 py-3 font-medium transition-colors whitespace-nowrap ${
+                  activeTab === 'geography'
+                    ? 'text-blue-600 border-b-2 border-blue-600'
+                    : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+                }`}
+              >
+                地理
+              </button>
+              <button
+                onClick={() => setActiveTab('cultures')}
+                className={`px-4 sm:px-6 py-3 font-medium transition-colors whitespace-nowrap ${
+                  activeTab === 'cultures'
+                    ? 'text-blue-600 border-b-2 border-blue-600'
+                    : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+                }`}
+              >
+                文化
+              </button>
+              <button
+                onClick={() => setActiveTab('magic')}
+                className={`px-4 sm:px-6 py-3 font-medium transition-colors whitespace-nowrap ${
+                  activeTab === 'magic'
+                    ? 'text-blue-600 border-b-2 border-blue-600'
+                    : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+                }`}
+              >
+                <span className="hidden sm:inline">魔法・特殊能力</span>
+                <span className="sm:hidden">魔法</span>
+              </button>
+              <button
+                onClick={() => setActiveTab('map')}
+                className={`px-4 sm:px-6 py-3 font-medium transition-colors whitespace-nowrap ${
+                  activeTab === 'map'
+                    ? 'text-blue-600 border-b-2 border-blue-600'
+                    : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+                }`}
+              >
+                地図
+              </button>
+              <button
+                onClick={() => setActiveTab('travel')}
+                className={`px-4 sm:px-6 py-3 font-medium transition-colors whitespace-nowrap ${
+                  activeTab === 'travel'
+                    ? 'text-blue-600 border-b-2 border-blue-600'
+                    : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+                }`}
+              >
+                <span className="hidden sm:inline">旅行シミュレーター</span>
+                <span className="sm:hidden">旅行</span>
+              </button>
+            </div>
           </div>
 
           <div className="p-6">


### PR DESCRIPTION
Fixes #51 - スマホでのデザイン

## Changes
- Make project page header stack vertically on mobile with responsive button labels
- Add horizontal scrolling for tabs on world and rules pages to prevent vertical wrapping
- Fix dark mode styling for textarea in rules page for better text visibility
- Add responsive breakpoints and improved mobile layouts throughout

Generated with [Claude Code](https://claude.ai/code)