### PR TITLE
fix: TypeScript型エラーを修正 - MapConnectionの型安全性を向上

### DIFF
--- a/src/lib/services/world-map-service.ts
+++ b/src/lib/services/world-map-service.ts
@@ -255,12 +255,12 @@ export class WorldMapService {
     const processedPairs = new Set<string>()
 
     // 地形を考慮した接続可能性をチェック
-    const canConnect = (loc1: any, loc2: any, worldMap: WorldMap): { canConnect: boolean; difficulty: string; type: string } => {
+    const canConnect = (loc1: any, loc2: any, worldMap: WorldMap): { canConnect: boolean; difficulty: 'easy' | 'moderate' | 'difficult' | 'dangerous'; type: 'road' | 'path' | 'river' | 'sea_route' | 'air_route' | 'magical' } => {
       const distance = this.calculateDistance(loc1.coordinates, loc2.coordinates)
       
       // 地形の影響を確認
-      let terrainDifficulty = 'easy'
-      let connectionType = 'road'
+      let terrainDifficulty: 'easy' | 'moderate' | 'difficult' | 'dangerous' = 'easy'
+      let connectionType: 'road' | 'path' | 'river' | 'sea_route' | 'air_route' | 'magical' = 'road'
       
       // 地理的特徴を確認
       for (const feature of worldMap.geography || []) {
@@ -371,7 +371,7 @@ export class WorldMapService {
               toLocationId: edge.to.id,
               bidirectional: true,
               connectionType: edge.type,
-              difficulty: edge.difficulty as any,
+              difficulty: edge.difficulty,
               description: `${edge.from.name}と${edge.to.name}を結ぶ${edge.type === 'road' ? '街道' : '道'}`
             })
             added = true


### PR DESCRIPTION
## 概要
render.comでのデプロイ時にTypeScriptコンパイルエラーが発生していた問題を修正しました。

## 変更内容
- canConnect関数の戻り値の型を明示的に定義
- terrainDifficultyとconnectionTypeの変数に型注釈を追加
- 不要なany型キャストを削除

Closes #55

Generated with [Claude Code](https://claude.ai/code)