### PR TITLE
fix: TypeScript型エラーを修正 - 不要な型チェックを削除

### DIFF
--- a/src/lib/services/foreshadowing-tracker-service.ts
+++ b/src/lib/services/foreshadowing-tracker-service.ts
@@ -257,7 +257,7 @@ export class ForeshadowingTrackerService {
           suggestions.push(f)
         }
         // 物語の終盤で未回収
-        else if (nextChapterNumber >= totalChapters - 1 && f.status !== 'revealed') {
+        else if (nextChapterNumber >= totalChapters - 1) {
           suggestions.push(f)
         }
       })


### PR DESCRIPTION
## 概要

render.comでのデプロイ失敗を修正しました。

TypeScriptの型エラーが原因で、早期リターンにより既に`'revealed'`状態が除外されている箇所で、重複する型チェックを行っていました。

不要な条件を削除することで、TypeScriptの型エラーを解消しました。

Closes #63

Generated with [Claude Code](https://claude.ai/code)