### PR TITLE
feat: キャラクター生成制限の撤廃とAIデフォルト設定の更新

### DIFF
--- a/src/components/project/CreateProjectModal.tsx
+++ b/src/components/project/CreateProjectModal.tsx
@@ -484,7 +484,7 @@ export default function CreateProjectModal({ isOpen, onClose, onCreated }: Creat
                   <ul className="text-sm text-gray-600 dark:text-gray-400 space-y-1 list-disc list-inside">
                     <li>執筆ルール（視点、時制、文体）</li>
                     <li>世界観設定（時代、地理、文化）</li>
-                    <li>主要キャラクター（5-8人）</li>
+                    <li>主要キャラクター（物語に必要な人数）</li>
                     <li>キャラクター間の関係性</li>
                   </ul>
                   

--- a/src/lib/services/chapter-structure-service.ts
+++ b/src/lib/services/chapter-structure-service.ts
@@ -278,15 +278,6 @@ ${this.getForeshadowingGuidelines(chapterCount || 10)}
       // 超長編：最大限のトークンを使用
       maxTokens = 8000
       temperature = 0.7
-      // 必要に応じてより高性能なモデルを使用
-      if (baseSettings.model === 'gpt-4.1-mini') {
-        return {
-          ...baseSettings,
-          model: 'gpt-4o-mini',
-          maxTokens,
-          temperature
-        }
-      }
     }
     
     return {

--- a/src/lib/services/project-generator-service.ts
+++ b/src/lib/services/project-generator-service.ts
@@ -430,9 +430,9 @@ styleフィールドには以下を含めてください：
 
 【生成するキャラクター数】
 - 主人公（protagonist）: 1名
-- 敵対者（antagonist）: 1名（物語によっては不要な場合あり）
-- その他の重要キャラクター: 3-6名
-- 合計: 5-8名
+- 敵対者（antagonist）: 物語に必要な場合
+- その他の重要キャラクター: 物語の規模と複雑さに応じて適切な人数
+- 合計: 物語に必要な人数を柔軟に生成（最低3名以上）
 
 必ずJSON配列として、上記の形式に完全に準拠したキャラクターデータを返してください。`
 
@@ -444,7 +444,7 @@ styleフィールドには以下を含めてください：
 世界観:
 ${worldSettings.name} - ${worldSettings.description}
 
-5-8人程度の主要キャラクターを生成してください。`
+物語の規模と複雑さに応じて必要な主要キャラクターを生成してください。`
 
     const response = await this.generateWithAI(systemPrompt, userPrompt, model, temperature)
     

--- a/src/lib/services/project-service.ts
+++ b/src/lib/services/project-service.ts
@@ -52,9 +52,9 @@ class ProjectService {
           cultures: []
         },
         aiSettings: data.settings?.aiSettings || {
-          model: 'gpt-4o',
+          model: 'gpt-4.1-mini',
           temperature: 0.7,
-          maxTokens: 4000,
+          maxTokens: 32768,
           systemPrompt: '',
           customInstructions: []
         }

--- a/src/lib/utils/ai-settings.ts
+++ b/src/lib/utils/ai-settings.ts
@@ -5,42 +5,42 @@ export const DEFAULT_MODEL_SETTINGS: AIModelSettings = {
   defaultModel: {
     model: 'gpt-4.1-mini',
     temperature: 0.7,
-    maxTokens: 4000
+    maxTokens: 32768
   },
   chapterWriting: {
-    model: 'gpt-4o',
+    model: 'gpt-4.1-mini',
     temperature: 0.8,
-    maxTokens: 5000
+    maxTokens: 32768
   },
   chapterPlanning: {
     model: 'gpt-4.1-mini',
     temperature: 0.5,
-    maxTokens: 2000
+    maxTokens: 32768
   },
   backgroundEvents: {
-    model: 'gpt-4o-mini',
+    model: 'gpt-4.1-mini',
     temperature: 0.3,
-    maxTokens: 1000
+    maxTokens: 32768
   },
   summarization: {
     model: 'gpt-4.1-mini',
     temperature: 0.3,
-    maxTokens: 500
+    maxTokens: 32768
   },
   characterAnalysis: {
     model: 'gpt-4.1-mini',
     temperature: 0.5,
-    maxTokens: 2000
+    maxTokens: 32768
   },
   validation: {
-    model: 'gpt-4o-mini',
+    model: 'gpt-4.1-mini',
     temperature: 0.3,
-    maxTokens: 1000
+    maxTokens: 32768
   },
   assistant: {
     model: 'gpt-4.1-mini',
     temperature: 0.7,
-    maxTokens: 2000
+    maxTokens: 32768
   }
 }
 


### PR DESCRIPTION
## 概要

このPull Requestは #65 で要望された2つの変更を実装します。

## 変更内容

### 1. キャラクター生成制限の撤廃
- AIが5-8人に制限されていたキャラクター生成を、物語の規模と複雑さに応じて柔軟に生成可能に
- UIテキストも同様に更新

### 2. AIデフォルト設定の統一
- 全てのAI機能のデフォルトモデルを`gpt-4.1-mini`に統一
- maxTokensを32768に変更
- 不要なモデル自動切り替えロジックを削除

Fixes #65

Generated with [Claude Code](https://claude.ai/code)