### PR TITLE
fix: TypeScript型エラーを修正 - Foreshadowingカテゴリの値を正しい型に合わせる

### DIFF
--- a/src/lib/services/foreshadowing-context-builder.ts
+++ b/src/lib/services/foreshadowing-context-builder.ts
@@ -136,13 +136,13 @@ export class ForeshadowingContextBuilder {
         case 'character':
           contextual.suggestedResolution = 'キャラクターの行動や対話を通じて明かす'
           break
-        case 'worldbuilding':
+        case 'world':
           contextual.suggestedResolution = '世界観の描写や説明の中で自然に明かす'
           break
         case 'plot':
           contextual.suggestedResolution = '物語の展開の中で必然的に明かす'
           break
-        case 'theme':
+        case 'other':
           contextual.suggestedResolution = 'テーマに関連する出来事や省察を通じて明かす'
           break
         case 'mystery':


### PR DESCRIPTION
## 概要

render.comでのリデプロイ時にTypeScriptの型エラーが発生していた問題を修正しました。

## 変更内容

- `foreshadowing-context-builder.ts`のswitch文で使用されているカテゴリ値を`Foreshadowing`インターフェースで定義されている正しい値に修正
  - `'worldbuilding'` → `'world'`
  - `'theme'` → `'other'`

Closes #71

Generated with [Claude Code](https://claude.ai/code)