### PR TITLE
fix: リデプロイ失敗のTypeScriptエラーを修正

### DIFF
--- a/src/lib/services/foreshadowing-resolution-validator.ts
+++ b/src/lib/services/foreshadowing-resolution-validator.ts
@@ -1,6 +1,5 @@
 import { Chapter, Foreshadowing } from '@/lib/types'
 import { aiManager } from '@/lib/ai/manager'
-import { getFeatureModelSettings } from '@/lib/utils/ai-settings'
 
 export interface ForeshadowingResolutionValidation {
   foreshadowingHint: string
@@ -24,8 +23,6 @@ export class ForeshadowingResolutionValidator {
       return []
     }
 
-    const modelSettings = getFeatureModelSettings('chapterGeneration', aiModel)
-    
     // 各伏線の詳細情報を取得
     const foreshadowingMap = new Map<string, Foreshadowing>()
     foreshadowingDetails.forEach(f => {
@@ -69,7 +66,7 @@ ${plannedResolutions.map(hint => {
 
     try {
       const response = await aiManager.complete({
-        model: modelSettings.model,
+        model: aiModel,
         messages: [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userPrompt }


### PR DESCRIPTION
## 概要

render.comでのデプロイ失敗の原因となっていたTypeScriptエラーを修正しました。

## 変更内容

- `foreshadowing-resolution-validator.ts`の`getFeatureModelSettings`の誤った使用を削除
- `aiModel`パラメータを直接使用するように変更
- 未使用のインポートを削除

Fixes #73

Generated with [Claude Code](https://claude.ai/code)