### PR TITLE
fix: correct property access in AI usage check

### DIFF
--- a/src/app/api/ai/complete/route.ts
+++ b/src/app/api/ai/complete/route.ts
@@ -61,9 +61,9 @@ export async function POST(request: NextRequest) {
 
     // Check AI usage limits
     const canGenerate = await AIUsageService.canGenerateChapter(session.user.id);
-    if (!canGenerate.allowed) {
+    if (!canGenerate.canGenerate) {
       return NextResponse.json(
-        { error: canGenerate.reason || 'AI usage limit exceeded' },
+        { error: 'AI usage limit exceeded' },
         { status: 403 }
       );
     }


### PR DESCRIPTION
Fixes #81 

## Summary
- Fixed TypeScript compilation error in production build
- Changed `canGenerate.allowed` to `canGenerate.canGenerate`
- Removed non-existent `reason` property reference

Generated with [Claude Code](https://claude.ai/code)