### PR TITLE
fix: TypeScript型エラーを修正（デプロイビルド失敗の解決）

### DIFF
--- a/src/app/api/ai/complete/route.ts
+++ b/src/app/api/ai/complete/route.ts
@@ -34,7 +34,7 @@ function getProvider(providerName: string): AIProvider {
           minPromptLength: 100
         }) as any; // Cast to keep type compatibility
       }
-      return openAIProvider;
+      return openAIProvider as AIProvider;
     
     case 'anthropic':
       if (!anthropicProvider) {
@@ -55,7 +55,7 @@ function getProvider(providerName: string): AIProvider {
           minPromptLength: 100
         }) as any; // Cast to keep type compatibility
       }
-      return anthropicProvider;
+      return anthropicProvider as AIProvider;
     
     default:
       throw new Error(`Unknown provider: ${providerName}`);


### PR DESCRIPTION
この修正は、render.comでのデプロイ時にTypeScriptの型エラーでビルドが失敗する問題を解決します。

## 変更内容
- `openAIProvider`と`anthropicProvider`の返却時に型アサーションを追加
- 初期化後は必ず非nullになることが保証されているため、安全な修正です

Closes #101

Generated with [Claude Code](https://claude.ai/code)