### PR TITLE
fix: デプロイエラーの修正 - TypeScript設定の更新

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
@@ -12,6 +13,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "downlevelIteration": true,
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
デプロイ時のTS5ターゲットでMap.entries()のイテレータが使えないエラーを修正しました。

## 変更内容
- TypeScriptのターゲットをES2017に設定
- downlevelIterationを有効化

これにより、`src/lib/ai/cache-provider.ts:156`でのビルドエラーが解消されます。

Closes #103

Generated with [Claude Code](https://claude.ai/code)