### PR TITLE
fix: Renderでのデプロイ失敗を修正

### DIFF
--- a/src/lib/ai/retry-provider.ts
+++ b/src/lib/ai/retry-provider.ts
@@ -71,6 +71,8 @@ export class RetryAIProvider implements AIProvider {
     let lastError: Error | null = null
 
     for (let attempt = 0; attempt < this.options.maxRetries; attempt++) {
+      let firstChunk = true
+
       try {
         if (!this.provider.completeStream) {
           throw new Error(`Provider ${this.provider.name} does not support streaming`)
@@ -79,7 +81,6 @@ export class RetryAIProvider implements AIProvider {
         // For streaming, we can't retry after starting to yield
         // So we only retry on initial connection errors
         const generator = this.provider.completeStream(options)
-        let firstChunk = true
 
         for await (const chunk of generator) {
           firstChunk = false


### PR DESCRIPTION
Fixes #105

## 概要

`src/lib/ai/retry-provider.ts` で発生していたTypeScriptコンパイルエラーを修正しました。

## 変更内容

- `firstChunk` 変数の宣言をtry-catchブロックの外側に移動
- これによりcatchブロックからも変数にアクセス可能に

Generated with [Claude Code](https://claude.ai/code)